### PR TITLE
Fix support for winston 3

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ module.exports = class LogDNATransport extends Transport {
         if (callback) { callback(); }
     }
 
-    // make sure all logs are flushed with the Stream closes
+    // make sure all logs are flushed when the Stream closes
     // https://nodejs.org/api/stream.html#stream_writable_final_callback
     _final(cb) {
         logdna.flushAll(cb);

--- a/index.js
+++ b/index.js
@@ -17,23 +17,21 @@ module.exports = class LogDNATransport extends Transport {
     log(info, callback) {
         setImmediate(() => this.emit('logged', info));
 
-        if (info instanceof Error) {
-            info = {
-                message: info.message
-                , level: 'error'
-                , error: info.stack || info.toString()
-            };
+        if (info.message instanceof Error) {
+            info.error = info.message.stack || info.message.toString();
+            info.message = info.message.message;
         }
 
         if (!info.message) {
             info.message = stringify(info, null, 2, function () { return undefined; });
         }
 
-        const { level, message, ...meta } = info;
+        const { level, message, index_meta, ...meta } = info;
+
         const opts = {
-            level: info.level
-            , index_meta: info.index_meta || this.index_meta
-            , context: meta || {}
+            level
+            , index_meta: index_meta !== undefined ? index_meta : this.index_meta
+            , meta: meta || {}
         };
 
         this.logger.log(info.message, opts);

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 const Transport = require('winston-transport');
-const Logger = require('logdna').Logger;
+const logdna = require('logdna');
 const stringify = require('json-stringify-safe');
 
 /*
@@ -10,7 +10,7 @@ module.exports = class LogDNATransport extends Transport {
         super(options);
         this.name = options.name || 'LogDNA';
         this.level = options.level || '';
-        this.logger = new Logger(options.key, options);
+        this.logger = new logdna.Logger(options.key, options);
         this.index_meta = options.index_meta || false;
     }
 
@@ -36,5 +36,11 @@ module.exports = class LogDNATransport extends Transport {
 
         this.logger.log(info.message, opts);
         if (callback) { callback(); }
+    }
+
+    // make sure all logs are flushed with the Stream closes
+    // https://nodejs.org/api/stream.html#stream_writable_final_callback
+    _final(cb) {
+        logdna.flushAll(cb);
     }
 };


### PR DESCRIPTION
In `winston` 3 the `log` function takes an [`info` object](https://github.com/winstonjs/winston#streams-objectmode-and-info-objects) and not `level`, `msg` and `meta` as separate parameters.

Currently `logdna-winston@^2` is still falling back to the legacy transport and the upgrade message is shown in `STDERR`:

```
LogDNA is a legacy winston transport. Consider upgrading:
- Upgrade docs: https://github.com/winstonjs/winston/blob/master/UPGRADE-3.0.md
```