### PR TITLE
deps: move `eslint` out of `dependencies` into `devDependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "logdna-winston",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "LogDNA's Node.js logging module with support for Winston",
   "main": "index.js",
   "scripts": {
@@ -30,11 +30,11 @@
   },
   "homepage": "https://github.com/logdna/logdna-winston#readme",
   "dependencies": {
-    "eslint": "^6.5.1",
     "logdna": "^3.5.0",
     "winston": "^3.2.1"
   },
   "devDependencies": {
-    "babel-eslint": "^10.0.3"
+    "babel-eslint": "^10.0.3",
+    "eslint": "^6.8.0"
   }
 }


### PR DESCRIPTION
## Summary
Similar to [this](https://github.com/logdna/logdna-bunyan/pull/16), this package must stop using/including `eslint` in the building process.

Semver: patch