### PR TITLE
fix(ci): Expose linter results in the junit output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 node_modules
 coverage
 .nyc_output
-.tap-output

--- a/.npmignore
+++ b/.npmignore
@@ -9,3 +9,4 @@ coverage
 .npm
 .tap-output
 Jenkinsfile
+tools

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -58,9 +58,7 @@ pipeline {
                 npm.auth token: "${GITHUB_PACKAGES_TOKEN}"
               }
 
-              sh """
-              npm install
-              """
+              sh 'npm install'
             }
           }
 
@@ -73,9 +71,7 @@ pipeline {
 
             post {
               always {
-                sh 'cat .tap-output | ./node_modules/.bin/tap-mocha-reporter xunit > coverage/test.xml'
-
-                junit 'coverage/test.xml'
+                junit checksName: 'Test Results', testResults: 'coverage/*.xml'
 
                 publishHTML target: [
                   allowMissing: false,

--- a/package.json
+++ b/package.json
@@ -5,8 +5,7 @@
   "main": "index.js",
   "scripts": {
     "lint": "eslint .",
-    "pretest": "npm run lint",
-    "test": "tap"
+    "test": "tools/test.sh"
   },
   "repository": {
     "type": "git",
@@ -40,6 +39,7 @@
     "eslint-config-logdna": "^2.0.0",
     "nock": "^13.0.4",
     "tap": "^14.10.8",
+    "tap-xunit": "^2.4.1",
     "winston": "^3.3.3"
   },
   "eslintConfig": {
@@ -76,6 +76,6 @@
     "files": [
       "test/**/*.js"
     ],
-    "output-file": ".tap-output"
+    "output-file": "coverage/.tap-output"
   }
 }

--- a/tools/test.sh
+++ b/tools/test.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+export PATH="./node_modules/.bin:$PATH"
+
+mkdir -p coverage
+
+tap && npm run lint -- -f tap -o coverage/.lint-output
+
+code=$?
+
+cat coverage/.tap-output | tap-parser -t -f | tap-xunit > coverage/tap-results.xml
+cat coverage/.lint-output | tap-parser -t -f | tap-xunit > coverage/lint-results.xml
+
+exit $code


### PR DESCRIPTION
This change will force linting on CI and expose any errors. It also
changes to using `tap-xunit` with a flattened output when generating
the junit report file. This solves a bug with tests missing when using
tap-mocha-reporter.

Semver: patch