### PR TITLE
BREAKING CHANGE: feat(levels)!: Support custom log levels in LogDNA

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,11 +55,11 @@ logger.add(new logdnaWinston(options));
 
 // log with meta
 logger.log({
-    level: 'info'
-    , message: 'Log from LogDNA-winston'
-    , indexMeta: true // Optional.  If not provided, it will use the default.
-    , data:'Some information' //  Properties besides level, message and indexMeta are considered as "meta"
-    , error: new Error("It's a trap.") // Transport will parse the error object under property 'error'
+  level: 'info'
+, message: 'Log from LogDNA-winston'
+, indexMeta: true // Optional.  If not provided, it will use the default.
+, data:'Some information' //  Properties besides level, message and indexMetaare considered as "meta"
+, error: new Error("It's a trap.") // Transport will parse the error object under property 'error'
 })
 
 // log without meta
@@ -73,6 +73,42 @@ logger.info({
 })
 ```
 
+## Custom Log Levels
+
+As per the Winston documentation, [custom log levels](https://github.com/winstonjs/winston#using-custom-logging-levels) may be used. In order to use such
+levels in LogDNA, [custom levels must be defined](https://github.com/logdna/logger-node#custom-log-levels) for that logger as well.
+
+```javascript
+  const levels = {
+    error: 0
+  , warn: 1
+  , info: 2
+  , http: 3
+  , verbose: 4
+  , loquacious: 5
+  , ludicrous: 6
+  }
+  const logger = winston.createLogger({
+    levels
+  , level: 'ludicrous' // needed, or else it won't log levels <= to 'info'
+  })
+
+  const logdna_options = {
+    key: 'abc123'
+  , levels: Object.keys(levels)
+  }
+  logger.add(new logdnaWinston(logdna_options))
+
+  // Now the custom levels can be logged in Winston and LogDNA
+  logger.ludicrous('Some text')
+
+  logger.log({
+    msg: 'Custom level log message'
+  , key: 'value'
+  , bool: true
+  , level: 'loquacious'
+  })
+```
 
 ## Contributors ✨
 

--- a/index.js
+++ b/index.js
@@ -4,16 +4,6 @@ const Transport = require('winston-transport')
 const {createLogger} = require('@logdna/logger')
 const pkg = require('./package.json')
 
-// Convert between Winston levels and @logdna/logger levels
-const levelTranslate = new Map([
-  ['error', 'error']
-, ['warn', 'warn']
-, ['info', 'info']
-, ['http', 'debug']
-, ['verbose', 'debug']
-, ['debug', 'debug']
-, ['silly', 'trace']
-])
 /*
  *  Support for Winston Transport
  */
@@ -29,7 +19,7 @@ module.exports = class LogDNATransport extends Transport {
   }
 
   log(info, callback) {
-    const level = levelTranslate.get(info.level)
+    const level = info.level
 
     if (info.error instanceof Error) {
       info.error = info.error.stack || info.error.toString()

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "winston-transport": "^4.4.0"
   },
   "devDependencies": {
-    "eslint": "^7.20.0",
+    "eslint": "^7.32.0",
     "eslint-config-logdna": "^4.0.2",
     "nock": "^13.0.4",
     "semantic-release": "^17.3.9",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "homepage": "https://github.com/logdna/logdna-winston#readme",
   "dependencies": {
-    "@logdna/logger": "^2.2.4",
+    "@logdna/logger": "^2.4.0",
     "winston-transport": "^4.4.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "eslint": "^7.32.0",
     "eslint-config-logdna": "^4.0.2",
     "nock": "^13.0.4",
-    "semantic-release": "^17.3.9",
+    "semantic-release": "^17.4.7",
     "semantic-release-config-logdna": "^1.1.0",
     "tap": "^14.10.8",
     "tap-xunit": "^2.4.1",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "eslint": "^7.32.0",
-    "eslint-config-logdna": "^4.0.2",
+    "eslint-config-logdna": "^5.1.0",
     "nock": "^13.0.4",
     "semantic-release": "^17.4.7",
     "semantic-release-config-logdna": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "eslint-config-logdna": "^4.0.2",
     "nock": "^13.0.4",
     "semantic-release": "^17.4.7",
-    "semantic-release-config-logdna": "^1.1.0",
+    "semantic-release-config-logdna": "^1.3.0",
     "tap": "^14.10.8",
     "tap-xunit": "^2.4.1",
     "winston": "^3.3.3"

--- a/test/index.js
+++ b/test/index.js
@@ -38,7 +38,7 @@ test('Call .log() with an object and indexMeta: true', (t) => {
   nock(options.url)
     .post('/', (body) => {
       const payload = body.ls[0]
-      t.deepEqual(payload, {
+      t.same(payload, {
         timestamp
       , line: message
       , level: 'INFO'
@@ -259,7 +259,7 @@ test('Error will still be processed if there is no stack trace', (t) => {
   nock(options.url)
     .post('/', (body) => {
       const payload = body.ls[0]
-      t.deepEqual(payload, {
+      t.same(payload, {
         timestamp
       , line: error.message
       , level: 'ERROR'


### PR DESCRIPTION
**feat(levels)!: Support custom log levels in LogDNA**

As Winston allows for the use of custom log levels, now
so does LogDNA. Custom levels can be defined for both
Winston and LogDNA such that those custom levels will
show up on LogDNA's log viewer.

BREAKING CHANGE: This removes the log level "translation"
that used to be in place to convert Winston levels to ones
that would be acceptable by LogDNA. Since LogDNA can now
define custom levels as well, this translation is no longer
needed, however it may break implementations that are
relying on the translated levels.

Fixes: #31

---

**chore(deps): eslint-config-logdna@5.1.0**


---

**chore(deps): semantic-release-config-logdna@1.3.0**


---

**chore(deps): semantic-release@17.4.7**


---

**chore(deps): eslint@7.32.0**
