### PR TITLE
fix(level): Separate concerns for the "level" parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,38 @@ Similarly, if no custom winston levels are used, then the Winston [default of "n
   })
 ```
 
+## The `maxLevel` Parameter
+
+Both the Winston logger and the LogDNA logger accept a `level` parameter, but they mean different things:
+
+* For Winston, `level` represents the maximum log level by priority. In other words, anything "higher" in priority number WILL NOT be logged.
+* In LogDNA, `level` represents a default log level which is used in the absence of a level being defined for each log entry. Since Winston always passed a log level, this parameter is not usable in this transport.
+
+To disambiguate the two `level` parameters (even though the LogDNA one cannot be used), this custom transport will accept the `maxLevel` parameter to be used as Winston's `level` parameter. This is **only needed if** `level` has not been defined during Winston's `createLogger` call prior to adding this custom transport.
+
+```js
+const winston = require('winston')
+const logdnaTransport = require('logdna-winston')
+
+const logger = winston.createLogger({
+  level: 'verbose'
+, transports:[new logdnaTransport({key: 'abc123'})]
+})
+logger.silly('This will not be logged')
+logger.verbose('This will be logged')
+
+// ...is the same as this
+ const logger = winston.createLogger({
+  transports:[
+    new logdnaTransport({
+      key: 'abc123'
+    , maxLevel: 'verbose'
+    })
+  ]
+})
+logger.silly('This will not be logged')
+logger.verbose('This will be logged')
+```
 ## Contributors ✨
 
 Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/docs/en/emoji-key)):

--- a/README.md
+++ b/README.md
@@ -76,7 +76,12 @@ logger.info({
 ## Custom Log Levels
 
 As per the Winston documentation, [custom log levels](https://github.com/winstonjs/winston#using-custom-logging-levels) may be used. In order to use such
-levels in LogDNA, [custom levels must be defined](https://github.com/logdna/logger-node#custom-log-levels) for that logger as well.
+levels in LogDNA, [custom levels must be defined](https://github.com/logdna/logger-node#custom-log-levels) for that logger as well. If `levels` is passed to this transport, they
+will **automatically** be configured as custom levels for the LogDNA logger.
+
+Similarly, if no custom winston levels are used, then the Winston [default of "npm" levels](https://github.com/winstonjs/winston#logging-levels) will be automatically configured for LogDNA to understand. 
+
+**NOTE:** The "levels" parameter is in the context of Winston, thus it should be an object where the keys are the level names, and the values are a numeric priority.
 
 ```javascript
   const levels = {
@@ -95,7 +100,6 @@ levels in LogDNA, [custom levels must be defined](https://github.com/logdna/logg
 
   const logdna_options = {
     key: 'abc123'
-  , levels: Object.keys(levels)
   }
   logger.add(new logdnaWinston(logdna_options))
 

--- a/index.js
+++ b/index.js
@@ -9,11 +9,31 @@ const pkg = require('./package.json')
  */
 module.exports = class LogDNATransport extends Transport {
   constructor(options) {
-    super(options)
+    const {levels, ...opts} = options
+    super({
+      ...opts
+    , levels
+    })
 
+    let custom_levels = levels
+    if (!custom_levels) {
+      // Per the winston docs, their 'npm' levels will be used, and those must be
+      // set up as custom levels in LogDNA.
+      // @see https://github.com/winstonjs/winston#logging-levels
+      custom_levels = {
+        error: 0
+      , warn: 1
+      , info: 2
+      , http: 3
+      , verbose: 4
+      , debug: 5
+      , silly: 6
+      }
+    }
     // Create an instance of @logdna/logger
     this.logger = createLogger(options.key, {
-      ...options
+      ...opts
+    , levels: Object.keys(custom_levels)
     , UserAgent: `${pkg.name}/${pkg.version}`
     })
   }

--- a/index.js
+++ b/index.js
@@ -9,10 +9,11 @@ const pkg = require('./package.json')
  */
 module.exports = class LogDNATransport extends Transport {
   constructor(options) {
-    const {levels, ...opts} = options
+    const {levels, maxLevel, key, ...opts} = options
     super({
       ...opts
     , levels
+    , level: maxLevel
     })
 
     let custom_levels = levels
@@ -31,7 +32,7 @@ module.exports = class LogDNATransport extends Transport {
       }
     }
     // Create an instance of @logdna/logger
-    this.logger = createLogger(options.key, {
+    this.logger = createLogger(key, {
       ...opts
     , levels: Object.keys(custom_levels)
     , UserAgent: `${pkg.name}/${pkg.version}`


### PR DESCRIPTION
**fix(level): Separate concerns for the "level" parameter**

Both Winston and LogDNA have a "level" parameter, but they
mean different things. In Winston, it represents a "max"
level wherein anything logged above that level's rank will
not be logged (and thus sent to LogDNA). To disambiguate
this logger transport, the parameter will be called `maxLevel`,
and will only apply to Winston. LogDNA's `level` parameter is
actually not usable with the implementation of this transport
since all logs will be specifying a level value.

Fixes: #33

---

**fix(levels): Automatically set up LogDNA custom levels for defaults**

Winston uses "levels" as an object where the values are numeric.
If no levels are specified, it uses the "npm" levels that are
defined in their docs. These levels are not all supported by
LogDNA, so if "levels" is used, automatically set up custom
LogDNA levels based on the keys of the winston levels object.